### PR TITLE
Added User File and Stored User's Profile Picture and Name

### DIFF
--- a/MusicTaste/MusicTaste.xcodeproj/project.pbxproj
+++ b/MusicTaste/MusicTaste.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		459577C128760D9A00D566DE /* MatchmakingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 459577C028760D9A00D566DE /* MatchmakingViewController.m */; };
 		459577C428760DB800D566DE /* ProfileViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 459577C328760DB800D566DE /* ProfileViewController.m */; };
 		45B0EA52287EF86E00C4ABD2 /* LoginViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 45B0EA51287EF86E00C4ABD2 /* LoginViewController.m */; };
+		45FDD0532881B55F003483A5 /* User.m in Sources */ = {isa = PBXBuildFile; fileRef = 45FDD0522881B55F003483A5 /* User.m */; };
 		5302006FE955DF688B280E5A /* Pods_MusicTasteTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD6761B3501A7DCBBD555BF1 /* Pods_MusicTasteTests.framework */; };
 		68836B6E5AD463096802F15E /* Pods_MusicTaste.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E3AC11E3EF09D70605DD95D2 /* Pods_MusicTaste.framework */; };
 		7EA3B509A988087A8718BFAE /* Pods_MusicTasteUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04285ABD86E27BB8B7A101AC /* Pods_MusicTasteUITests.framework */; };
@@ -82,6 +83,8 @@
 		459577C328760DB800D566DE /* ProfileViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ProfileViewController.m; sourceTree = "<group>"; };
 		45B0EA50287EF86E00C4ABD2 /* LoginViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LoginViewController.h; sourceTree = "<group>"; };
 		45B0EA51287EF86E00C4ABD2 /* LoginViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LoginViewController.m; sourceTree = "<group>"; };
+		45FDD0512881B55F003483A5 /* User.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = User.h; sourceTree = "<group>"; };
+		45FDD0522881B55F003483A5 /* User.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = User.m; sourceTree = "<group>"; };
 		72591BDFFA3BFA9B3F91603D /* Pods-MusicTaste.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MusicTaste.release.xcconfig"; path = "Pods/Target Support Files/Pods-MusicTaste/Pods-MusicTaste.release.xcconfig"; sourceTree = "<group>"; };
 		7BCEEB28C3CCC4CE38BF9D3D /* Pods-MusicTaste.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MusicTaste.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MusicTaste/Pods-MusicTaste.debug.xcconfig"; sourceTree = "<group>"; };
 		AFB78AFA4A4E6C836384A772 /* Pods-MusicTasteUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MusicTasteUITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MusicTasteUITests/Pods-MusicTasteUITests.release.xcconfig"; sourceTree = "<group>"; };
@@ -199,6 +202,8 @@
 		459577862874F04300D566DE /* MusicTaste */ = {
 			isa = PBXGroup;
 			children = (
+				45FDD0522881B55F003483A5 /* User.m */,
+				45FDD0512881B55F003483A5 /* User.h */,
 				4578A3E62876526C00EB96A0 /* Cells */,
 				4578A3E72876527B00EB96A0 /* APIManagers */,
 				459577C528760DBF00D566DE /* View Controllers */,
@@ -479,6 +484,7 @@
 				4595778C2874F04300D566DE /* SceneDelegate.m in Sources */,
 				459577C428760DB800D566DE /* ProfileViewController.m in Sources */,
 				459577BE28760D8900D566DE /* ConnectViewController.m in Sources */,
+				45FDD0532881B55F003483A5 /* User.m in Sources */,
 				455B2EE32878B85D00524595 /* ConnectView.m in Sources */,
 				45B0EA52287EF86E00C4ABD2 /* LoginViewController.m in Sources */,
 				459577C128760D9A00D566DE /* MatchmakingViewController.m in Sources */,

--- a/MusicTaste/MusicTaste/APIManagers/SpotifyAPIManager.h
+++ b/MusicTaste/MusicTaste/APIManagers/SpotifyAPIManager.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <SpotifyiOS/SpotifyiOS.h>
+#import "User.h"
 
 NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
@@ -11,6 +12,7 @@ NS_ASSUME_NONNULL_END
 @property (nonatomic, strong) SPTSessionManager *sessionManager;
 @property (nonatomic, strong) SPTConfiguration *configuration;
 @property (nonatomic, strong) NSString *token;
+@property (nonatomic, strong) User *user;// Contains Users author's name, screenname, and profile image.
 @property (weak) IBOutlet UIWindow *window;
 
 

--- a/MusicTaste/MusicTaste/Base.lproj/Main.storyboard
+++ b/MusicTaste/MusicTaste/Base.lproj/Main.storyboard
@@ -280,6 +280,10 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="Swl-rn-oj0"/>
+                    <connections>
+                        <outlet property="profileView" destination="33c-SI-ggc" id="Bq6-FU-A04"/>
+                        <outlet property="screen_name" destination="WVV-Vf-6dK" id="5qU-so-Vmm"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="IVC-fJ-2UQ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/MusicTaste/MusicTaste/User.h
+++ b/MusicTaste/MusicTaste/User.h
@@ -1,0 +1,17 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface User : NSObject<NSCoding>
+//Properties
+
+@property (nonatomic, strong) NSString *name;
+@property (nonatomic, strong) NSString *profilePicture;
+
+//Initializer
++ (User *) user;
+- (void)encodeWithCoder:(NSCoder *)enCoder;
+- (id)initWithCoder:(NSCoder *)aDecoder;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/MusicTaste/MusicTaste/User.m
+++ b/MusicTaste/MusicTaste/User.m
@@ -1,0 +1,44 @@
+#import "User.h"
+
+@implementation User
+//Generate name and profile pticture
+@synthesize name,profilePicture;
+
++ (User *) user {
+    static User *user = nil;
+    if (!user) {
+        //initliaze User
+        user = [[super allocWithZone:nil] init];
+    }
+    return user;
+}
+
++ (id) allocWithZone:(struct _NSZone *)zone {
+    return [self user];
+}
+- (id) init {
+    self = [super init];
+    if (self) {
+        //initializes name and profile picture
+        name = nil;
+        profilePicture = nil;
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)encoder {
+    //Encode properties such as name and the profile picture
+    [encoder encodeObject:self.name forKey:@"name"];
+    [encoder encodeObject:self.profilePicture forKey:@"image"];
+}
+
+- (id)initWithCoder:(NSCoder *)decoder {
+    if((self = [super init])) {
+        //decode name and image
+        self.name = [decoder decodeObjectForKey:@"name"];
+        self.profilePicture = [decoder decodeObjectForKey:@"image"];
+    }
+    return self;
+}
+
+@end

--- a/MusicTaste/MusicTaste/View Controllers/ProfileViewController.m
+++ b/MusicTaste/MusicTaste/View Controllers/ProfileViewController.m
@@ -1,13 +1,30 @@
 #import "ProfileViewController.h"
+#import "UIImageView+AFNetworking.h"
+#import "User.h"
 
 @interface ProfileViewController () 
+//connects objects: Screenname and profileview
+@property (weak, nonatomic) IBOutlet UILabel *screen_name;
+@property (weak, nonatomic) IBOutlet UIImageView *profileView;
+
 
 @end
 
 @implementation ProfileViewController
-    
+
 - (void)viewDidLoad {
     [super viewDidLoad];
+    //Sets username
+    self.screen_name.text = [[User user] name];
+    //Gets image Url
+    NSString *URLString = [[User user] profilePicture];
+    NSString *stringWithoutNormal = [URLString stringByReplacingOccurrencesOfString:@"_normal" withString:@""];
+    NSURL *urlNew = [NSURL URLWithString:stringWithoutNormal];
+    [self.profileView setImageWithURL: urlNew];
+    //Makes image Circle
+    self.profileView.layer.cornerRadius = self.profileView.frame.size.height/2;
+    self.profileView.layer.masksToBounds = YES;
+    self.profileView.layer.borderWidth = 0;
     
 }
 


### PR DESCRIPTION
- Added User File
- Added encoding and decoding function in User.m
- Renamed Save Data to Save Spotify Data
- Added function in Spotify Manager called SaveSpotifyUserData
- SaveSpotifyUserData saves the current users Profile Picture and Name
- Display the User's Profile Picture and name on ProfileViewController

Test Case
- Used Break points and NSLog to see if the objects were stored correctly
- Checked IOS Simulator to see if the profile picture and name displayed properly

https://user-images.githubusercontent.com/103143506/179572933-038375e2-7bf2-4fa2-a34e-8f95ac960cda.mov
